### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Healthcheck is a library for implementing Kubernetes [liveness and readiness](ht
 
 ## Usage
 
-See the [GoDoc examples](https://godoc.org/github.com/heptio-labs/healthcheck) for more detail.
+See the [GoDoc examples](https://godoc.org/github.com/heptiolabs/healthcheck) for more detail.
 
- - Install with `go get` or your favorite Go dependency manager: `go get -u github.com/heptio-labs/healthcheck`
+ - Install with `go get` or your favorite Go dependency manager: `go get -u github.com/heptiolabs/healthcheck`
 
- - Import the package: `import "github.com/heptio-labs/healthcheck"`
+ - Import the package: `import "github.com/heptiolabs/healthcheck"`
 
  - Create a `healthcheck.Handler`:
    ```go

--- a/types.go
+++ b/types.go
@@ -50,16 +50,3 @@ type Handler interface {
 	// useful if you need to attach it into your own HTTP handler tree.
 	ReadyEndpoint(http.ResponseWriter, *http.Request)
 }
-
-// Trigger represents a health check that is tripped by a discrete event such
-// as a batch job failing.
-type Trigger interface {
-	// Trip sets the current status of the Trigger to the specified error
-	Trip(error)
-
-	// Reset the trigger to a healthy state (shorthand for Trip(nil)).
-	Reset()
-
-	// Check returns a check function suitable for `Handler.AddHealthCheck`.
-	Check() Check
-}


### PR DESCRIPTION
Fixes a couple of small issues I noticed combing through this just now:
 - I had accidentally left the `Trigger` interface definition in `types.go` even though it's now unused.
 - We are now live on https://github.com/heptiolabs!