### PR TITLE
Add database/sql ping check.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,9 +61,15 @@
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
+[[projects]]
+  name = "gopkg.in/DATA-DOG/go-sqlmock.v1"
+  packages = ["."]
+  revision = "d76b18b42f285b792bf985118980ce9eacea9d10"
+  version = "v1.3.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eaa528ab58d407850e6d906e86cb692ba19bc78045f5856a01e1cb47c64441a2"
+  inputs-digest = "044076023b3d86dbc55581284b8dceffad716fc8800f4f013d94173d9c11cedb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Healthcheck is a library for implementing Kubernetes [liveness and readiness](ht
 
  - Supports asynchronous checks, which run in a background goroutine at a fixed interval. These are useful for expensive checks that you don't want to add latency to the liveness and readiness endpoints.
 
- - Includes a small library of generically useful checks for validating upstream DNS, TCP, and HTTP dependencies as well as checking basic health of the Go runtime.
+ - Includes a small library of generically useful checks for validating upstream DNS, TCP, HTTP, and database dependencies as well as checking basic health of the Go runtime.
 
 ## Usage
 
@@ -39,7 +39,10 @@ See the [GoDoc examples](https://godoc.org/github.com/heptiolabs/healthcheck) fo
    // Our app is not ready if we can't resolve our upstream dependency in DNS.
    health.AddReadinessCheck(
        "upstream-dep-dns",
-   	   healthcheck.DNSResolveCheck("upstream.example.com", 50*time.Millisecond))
+       healthcheck.DNSResolveCheck("upstream.example.com", 50*time.Millisecond))
+
+   // Our app is not ready if we can't connect to our database (`var db *sql.DB`) in <1s.
+   health.AddReadinessCheck("database", healthcheck.DatabasePingCheck(db, 1*time.Second))
    ```
 
  - Expose the `/live` and `/ready` endpoints over HTTP (on port 8086):

--- a/checks.go
+++ b/checks.go
@@ -16,6 +16,7 @@ package healthcheck
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -56,6 +57,19 @@ func HTTPGetCheck(url string, timeout time.Duration) Check {
 			return fmt.Errorf("returned status %d", resp.StatusCode)
 		}
 		return nil
+	}
+}
+
+// DatabasePingCheck returns a Check that validates connectivity to a
+// database/sql.DB using Ping().
+func DatabasePingCheck(database *sql.DB, timeout time.Duration) Check {
+	return func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		if database == nil {
+			return fmt.Errorf("database is nil")
+		}
+		return database.PingContext(ctx)
 	}
 }
 

--- a/checks_test.go
+++ b/checks_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func TestTCPDialCheck(t *testing.T) {
@@ -30,6 +31,14 @@ func TestHTTPGetCheck(t *testing.T) {
 	assert.NoError(t, HTTPGetCheck("https://heptio.com", 5*time.Second)())
 	assert.Error(t, HTTPGetCheck("http://heptio.com", 5*time.Second)(), "redirect should fail")
 	assert.Error(t, HTTPGetCheck("https://heptio.com/nonexistent", 5*time.Second)(), "404 should fail")
+}
+
+func TestDatabasePingCheck(t *testing.T) {
+	assert.Error(t, DatabasePingCheck(nil, 1*time.Second)(), "nil DB should fail")
+
+	db, _, err := sqlmock.New()
+	assert.NoError(t, err)
+	assert.NoError(t, DatabasePingCheck(db, 1*time.Second)(), "ping should succeed")
 }
 
 func TestDNSResolveCheck(t *testing.T) {


### PR DESCRIPTION
This is the last basic check type I'd meant to add. It's very straightforward given that `database/sql` already includes `Ping()`/`PingContext()` in the interface.

The `DB.Ping` function is almost usable directly as a `Check`, but it's awkward to use with a proper timeout since you have to pass in a context. It's easy to fumble it and either forget the timeout or forget to cancel the timeout.

### Before
```go
health.AddReadinessCheck("database", func() error {
	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
	defer cancel()
	return db.PingContext(ctx)
})
```

### After
```go
health.AddReadinessCheck("database", healthcheck.DatabasePingCheck(db, 1*time.Second))
```