### PR TITLE
Add context to Check

### DIFF
--- a/async.go
+++ b/async.go
@@ -52,7 +52,7 @@ func AsyncWithContext(ctx context.Context, check Check, interval time.Duration) 
 	// make a wrapper that runs the check, and swaps out the current head of
 	// the channel with the latest result
 	update := func() {
-		err := check()
+		err := check(ctx)
 		<-result
 		result <- err
 	}
@@ -76,7 +76,7 @@ func AsyncWithContext(ctx context.Context, check Check, interval time.Duration) 
 	}()
 
 	// return a Check function that closes over our result and mutex
-	return func() error {
+	return func(_ context.Context) error {
 		// peek at the head of the channel, then put it back
 		err := <-result
 		result <- err

--- a/async_test.go
+++ b/async_test.go
@@ -23,20 +23,20 @@ import (
 )
 
 func TestAsync(t *testing.T) {
-	async := Async(func() error {
+	async := Async(func(ctx context.Context) error {
 		time.Sleep(50 * time.Millisecond)
 		return nil
 	}, 1*time.Millisecond)
 
 	// expect the first call to return ErrNoData since it takes 50ms to return the first time
-	assert.EqualError(t, async(), "no data yet")
+	assert.EqualError(t, async(context.Background()), "no data yet")
 
 	// wait for the first run to finish
 	time.Sleep(100 * time.Millisecond)
 
 	// make sure the next call returns nil ~immediately
 	start := time.Now()
-	assert.NoError(t, async())
+	assert.NoError(t, async(context.Background()))
 	assert.WithinDuration(t, time.Now(), start, 1*time.Millisecond,
 		"expected async() to return almost immediately")
 }
@@ -46,7 +46,7 @@ func TestAsyncWithContext(t *testing.T) {
 
 	// start an async check that counts how many times it was called
 	calls := 0
-	AsyncWithContext(ctx, func() error {
+	AsyncWithContext(ctx, func(ctx context.Context) error {
 		calls++
 		time.Sleep(1 * time.Millisecond)
 		return nil

--- a/example_test.go
+++ b/example_test.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/http"
@@ -23,10 +24,9 @@ import (
 	"strings"
 	"time"
 
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func Example() {
@@ -109,7 +109,7 @@ func Example_advanced() {
 		HTTPGetCheck(upstreamURL, 500*time.Millisecond))
 
 	// Implement a custom check with a 50 millisecond timeout.
-	health.AddLivenessCheck("custom-check-with-timeout", Timeout(func() error {
+	health.AddLivenessCheck("custom-check-with-timeout", Timeout(func(ctx context.Context) error {
 		// Simulate some work that could take a long time
 		time.Sleep(time.Millisecond * 100)
 		return nil
@@ -146,12 +146,12 @@ func Example_metrics() {
 	health := NewMetricsHandler(registry, "example")
 
 	// Add a simple readiness check that always fails.
-	health.AddReadinessCheck("failing-check", func() error {
+	health.AddReadinessCheck("failing-check", func(ctx context.Context) error {
 		return fmt.Errorf("example failure")
 	})
 
 	// Add a liveness check that always succeeds
-	health.AddLivenessCheck("successful-check", func() error {
+	health.AddLivenessCheck("successful-check", func(ctx context.Context) error {
 		return nil
 	})
 

--- a/metrics_handler.go
+++ b/metrics_handler.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -66,7 +67,8 @@ func (h *metricsHandler) wrap(name string, check Check) Check {
 			ConstLabels: prometheus.Labels{"check": name},
 		},
 		func() float64 {
-			if check() == nil {
+			ctx := context.Background()
+			if check(ctx) == nil {
 				return 0
 			}
 			return 1

--- a/metrics_handler_test.go
+++ b/metrics_handler_test.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,13 +31,13 @@ func TestNewMetricsHandler(t *testing.T) {
 	handler := NewMetricsHandler(prometheus.DefaultRegisterer, "test")
 
 	for _, check := range []string{"aaa", "bbb", "ccc"} {
-		handler.AddLivenessCheck(check, func() error {
+		handler.AddLivenessCheck(check, func(ctx context.Context) error {
 			return nil
 		})
 	}
 
 	for _, check := range []string{"ddd", "eee", "fff"} {
-		handler.AddLivenessCheck(check, func() error {
+		handler.AddLivenessCheck(check, func(ctx context.Context) error {
 			return fmt.Errorf("failing health check %q", check)
 		})
 	}
@@ -74,7 +74,7 @@ test_healthcheck_status{check="fff"} 1
 
 func TestNewMetricsHandlerEndpoints(t *testing.T) {
 	handler := NewMetricsHandler(prometheus.NewRegistry(), "test")
-	handler.AddReadinessCheck("fail", func() error {
+	handler.AddReadinessCheck("fail", func(ctx context.Context) error {
 		return fmt.Errorf("failing readiness check")
 	})
 

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -15,17 +15,18 @@
 package healthcheck
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
 )
 
 func TestTimeout(t *testing.T) {
-	tooSlow := Timeout(func() error {
+	tooSlow := Timeout(func(ctx context.Context) error {
 		time.Sleep(10 * time.Millisecond)
 		return nil
 	}, 1*time.Millisecond)
-	err := tooSlow()
+	err := tooSlow(context.Background())
 	if _, isTimeoutError := err.(timeoutError); !isTimeoutError {
 		t.Errorf("expected a TimeoutError, got %v", err)
 	}
@@ -38,11 +39,11 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("expected Temporary() to be true, got %v", err)
 	}
 
-	notTooSlow := Timeout(func() error {
+	notTooSlow := Timeout(func(ctx context.Context) error {
 		time.Sleep(1 * time.Millisecond)
 		return nil
 	}, 10*time.Millisecond)
-	if err := notTooSlow(); err != nil {
+	if err := notTooSlow(context.Background()); err != nil {
 		t.Errorf("expected success, got %v", err)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -15,11 +15,12 @@
 package healthcheck
 
 import (
+	"context"
 	"net/http"
 )
 
 // Check is a health/readiness check.
-type Check func() error
+type Check func(ctx context.Context) error
 
 // Handler is an http.Handler with additional methods that register health and
 // readiness checks. It handles handle "/live" and "/ready" HTTP


### PR DESCRIPTION
`Check` interface should be context dependent to be able to gracefully close all synchronous checks after server shutdown or request cancelation